### PR TITLE
Prevent Takeoff when Cold Start is required

### DIFF
--- a/lua/autorun/swvr_enum.lua
+++ b/lua/autorun/swvr_enum.lua
@@ -6,8 +6,7 @@ swvr = swvr or {}
 
 swvr.Allegiances = swvr.Allegiances or {}
 swvr.Sides = swvr.Sides or {}
-
-local AllegianceMap = {}
+swvr.AllegianceMap = swvr.AllegianceMap or {}
 
 function swvr.GetAllegiances()
   return swvr.Allegiances
@@ -22,7 +21,7 @@ function swvr.RegisterSide(side)
 
   swvr.Sides[#swvr.Sides + 1] = side
 
-  AllegianceMap[string.upper(side)] = {}
+  swvr.AllegianceMap[string.upper(side)] = {}
 
   return #swvr.Sides
 end
@@ -32,18 +31,22 @@ function swvr.RegisterAllegiance(name, side)
   assert(isstring(side) or isnumber(side), "Cannot register allegiance with side of type \"" .. type(side) .. "\"! Side names must be of type \"string\" or \"number\".")
 
   for i, v in ipairs(swvr.Allegiances) do
-    if string.upper(v) == string.upper(side) then return i end
+    if isnumber(side) then
+      if string.upper(v) == string.upper(name) then return i end
+    elseif isstring(side) then
+      if string.upper(v) == string.upper(side) then return i end
+    end
   end
 
   swvr.Allegiances[#swvr.Allegiances + 1] = name
 
   if isnumber(side) then
     for i, v in ipairs(swvr.Sides) do
-      if i == side then table.insert(AllegianceMap[v:upper()], name) end
+      if i == side then table.insert(swvr.AllegianceMap[v:upper()], name) end
     end
   elseif isstring(side) then
     for _, v in ipairs(swvr.Sides) do
-      if v:lower() == side:lower() then table.insert(AllegianceMap[side:upper()], name) break end
+      if v:lower() == side:lower() then table.insert(swvr.AllegianceMap[side:upper()], name) break end
     end
   end
 
@@ -57,7 +60,7 @@ end
 function swvr.GetSide(value)
   if isstring(value) then
     for i, side in ipairs(swvr.Sides) do
-      for _, al in ipairs(AllegianceMap[side:upper()]) do
+      for _, al in ipairs(swvr.AllegianceMap[side:upper()]) do
         if string.match(string.upper(al), string.upper(value)) then return i end
       end
     end

--- a/lua/entities/swvr_base/init.lua
+++ b/lua/entities/swvr_base/init.lua
@@ -438,6 +438,9 @@ function ENT:Takeoff()
   if self:GetVehicleState() ~= SWVR_STATE_IDLE then return false end
 
   if not self:EngineActive() then
+    -- Don't start anything on takeoff if manual cold start is needed.
+    if self.ColdStart then return end
+
     self:ToggleEngine()
   end
 

--- a/lua/entities/swvr_base/init.lua
+++ b/lua/entities/swvr_base/init.lua
@@ -739,11 +739,8 @@ function ENT:OnTakeDamage(dmg)
   self.NextShieldThink = CurTime() + self.ShieldRegenTime
 
   local damage = dmg:GetDamage()
-  local cur_health = self:Health()
-  local new_health = math.max(cur_health - damage, 0)
 
   if self:GetMaxShield() > 0 and self:GetShield() > 0 then
-    -- self:SetNextShieldRecharge(CurTime() + 3)
     dmg:SetDamagePosition(dmg:GetDamagePosition() + dmg:GetDamageForce():GetNormalized() * 250)
     self:ShieldDamage()
     
@@ -765,7 +762,6 @@ function ENT:OnTakeDamage(dmg)
     fx:SetNormal(dmg:GetDamageForce():GetNormalized())
 
     util.Effect("MetalSpark", fx)
-  end
 
     -- TODO: Crash landing mode
     if new_health <= 0 and not (self:GetShield() > damage and shield) and not self.Done then


### PR DESCRIPTION
Actually also prevents a bug of the ship jumping to map origin.
I think that when cold start is enabled ("Let's call it RP-Mode") It should be required to actually start the engine and not spam Launch until it's online. That's why i prevented it altogether